### PR TITLE
Change the Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Libre Office operates under a variety of licenses, but the primary two are:
 1.Mozilla Public License v2.0, and 2.
  Apache Open License. The software is based on code from Apache Open Office but may also incorporate items from various other open softwares which change from version to version.
 # How to get the source code
-The source code is available in three ways:  
-1.Clone from the anongit repository, git clone git://anongit.freedesktop.org/libreoffice/core
-2.Clone using the HTTP Protocol git clone http://anongit.freedesktop.org/git/libreoffice/core.git 
-3.Downloading the tarball.
+The source code is available in three ways:
+1. Clone from the anongit repository, git clone git://anongit.freedesktop.org/libreoffice/core
+2. Clone using the HTTP Protocol git clone http://anongit.freedesktop.org/git/libreoffice/core.git 
+3. Downloading the tarball.
 # How to report bugs or request features
 There is an email form you can fill out under the "Get Help" tab on the main site, libreoffice.org. There are other resources under the tab including community and professional support, forums, and frequently asked questions.
 # Fun fact


### PR DESCRIPTION
Numbered list in Markdown requires space after comma to show items line by line